### PR TITLE
Implement parsing benchmark

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Criterion.Main
+import Control.DeepSeq (($!!), NFData(..), deepseq)
+import qualified Data.ByteString.Char8 as BS8
+import Test.QuickCheck (arbitrary, generate)
+import Data.Attoparsec.ByteString.Char8 (Parser, parseOnly, char)
+
+import qualified Data.Time as Time
+import qualified Data.Thyme as Thyme
+import qualified System.Locale as Thyme
+import qualified Chronos
+
+main :: IO ()
+main = do
+  utcthyme <- generate arbitrary :: IO Thyme.UTCTime
+  let
+    isoFormatString = "%Y-%m-%dT%H:%M:%S%N"
+    renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale "%Y-%m-%dT%H:%M:%S%N"
+  string <- return $!! renderIsoTime utcthyme
+  bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
+
+  either (error . show) pure (parseOnly parseUtcTime bytestring)
+  defaultMain
+    [ bgroup "parsing"
+      [ bench "Thyme.parseTime" $ nf
+        ((Thyme.parseTime Thyme.defaultTimeLocale isoFormatString :: String -> Maybe Thyme.UTCTime))
+        string
+      , bench "Time.parseTimeM" $ nf
+        (Time.parseTimeM True Time.defaultTimeLocale isoFormatString :: String -> Maybe Time.UTCTime)
+        string
+      , bench "Thyme.timeParser" $ nf
+        (fmap (Thyme.buildTime @Thyme.UTCTime) . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString))
+        bytestring
+      , bench "Chronos.parser" $ nf
+        (parseOnly parseUtcTime)
+        bytestring
+      ]
+    ]
+
+parseUtcTime :: Parser Chronos.UtcTime
+parseUtcTime = do
+  date <- Chronos.parserUtf8_Ymd (Just '-')
+  char 'T'
+  timeOfDay <- Chronos.parserUtf8_HMS (Just ':')
+  pure $!!
+    Chronos.UtcTime
+      (Chronos.dateToDay date)
+      (Chronos.timeOfDayToNanosecondsSinceMidnight timeOfDay)
+
+instance NFData Chronos.UtcTime where
+  rnf (Chronos.UtcTime a b) = a `deepseq` b `deepseq` ()
+
+instance NFData Chronos.Day where
+  rnf (Chronos.Day i) = rnf i

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Main where
 
 import Criterion.Main
+import Data.Maybe (fromMaybe)
 import Control.DeepSeq (($!!), NFData(..), deepseq)
 import qualified Data.ByteString.Char8 as BS8
 import Test.QuickCheck (arbitrary, generate)
@@ -17,41 +21,48 @@ main :: IO ()
 main = do
   utcthyme <- generate arbitrary :: IO Thyme.UTCTime
   let
-    isoFormatString = "%Y-%m-%dT%H:%M:%S%N"
-    renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale "%Y-%m-%dT%H:%M:%S%N"
+    isoFormatString = "%Y-%m-%dT%H:%M:%S"
+    renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale isoFormatString
+    timeParser :: String -> Time.UTCTime
+    timeParser =
+      fromMaybe (error "Failed to parse in timeParser")
+      . Time.parseTimeM True Time.defaultTimeLocale isoFormatString
+    thymeParser :: String -> Thyme.UTCTime
+    thymeParser =
+      fromMaybe (error "Failed to parse in thymeParser")
+      . Thyme.parseTime Thyme.defaultTimeLocale isoFormatString
+    thymeAttoparsec :: BS8.ByteString -> Thyme.UTCTime
+    thymeAttoparsec =
+      Thyme.buildTime @Thyme.UTCTime
+      . either error id
+      . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString)
+    chronosAttoparsec :: BS8.ByteString -> Chronos.Datetime
+    chronosAttoparsec =
+      either error id
+      . parseOnly (Chronos.parserUtf8_YmdHMS Chronos.w3c)
+
   string <- return $!! renderIsoTime utcthyme
   bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
 
-  either (error . show) pure (parseOnly parseUtcTime bytestring)
   defaultMain
     [ bgroup "parsing"
-      [ bench "Thyme.parseTime" $ nf
-        ((Thyme.parseTime Thyme.defaultTimeLocale isoFormatString :: String -> Maybe Thyme.UTCTime))
-        string
-      , bench "Time.parseTimeM" $ nf
-        (Time.parseTimeM True Time.defaultTimeLocale isoFormatString :: String -> Maybe Time.UTCTime)
-        string
-      , bench "Thyme.timeParser" $ nf
-        (fmap (Thyme.buildTime @Thyme.UTCTime) . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString))
-        bytestring
-      , bench "Chronos.parser" $ nf
-        (parseOnly parseUtcTime)
-        bytestring
+      [ bench "Time.parseTimeM"           $ nf timeParser        string
+      , bench "Thyme.parseTime"           $ nf thymeParser       string
+      , bench "Thyme.timeParser"          $ nf thymeAttoparsec   bytestring
+      , bench "Chronos.parserUtf8_YmdHMS" $ nf chronosAttoparsec bytestring
       ]
     ]
 
-parseUtcTime :: Parser Chronos.UtcTime
-parseUtcTime = do
-  date <- Chronos.parserUtf8_Ymd (Just '-')
-  char 'T'
-  timeOfDay <- Chronos.parserUtf8_HMS (Just ':')
-  pure $!!
-    Chronos.UtcTime
-      (Chronos.dateToDay date)
-      (Chronos.timeOfDayToNanosecondsSinceMidnight timeOfDay)
+instance NFData Chronos.Datetime where
+  rnf (Chronos.Datetime a b) = a `deepseq` b `deepseq` ()
 
-instance NFData Chronos.UtcTime where
-  rnf (Chronos.UtcTime a b) = a `deepseq` b `deepseq` ()
+instance NFData Chronos.Date where
+  rnf (Chronos.Date y m d) = y `deepseq` m `deepseq` d `deepseq` ()
 
-instance NFData Chronos.Day where
-  rnf (Chronos.Day i) = rnf i
+instance NFData Chronos.TimeOfDay where
+  rnf (Chronos.TimeOfDay h m s) = h `deepseq` m `deepseq` s `deepseq` ()
+
+deriving instance NFData Chronos.DayOfMonth
+deriving instance NFData Chronos.Month
+deriving instance NFData Chronos.Year
+deriving instance NFData Chronos.Day

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -75,6 +75,23 @@ test-suite chronos-test
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+benchmark bench
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             Bench.hs
+  build-depends:
+      base
+    , attoparsec
+    , bytestring
+    , chronos
+    , criterion
+    , deepseq
+    , old-locale
+    , QuickCheck
+    , thyme
+    , time
+  default-language:    Haskell2010
+
 source-repository head
   type: git
   location: https://github.com/andrewthad/chronos

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -41,7 +41,6 @@ module Chronos
   , ordinalDateToDay
   , monthDateToDayOfYear
   , dayOfYearToMonthDay
-  , timeOfDayToNanosecondsSinceMidnight
     -- ** Build Timespan
   , second
   , minute
@@ -197,7 +196,6 @@ module Chronos
   , OffsetFormat(..)
   , DatetimeLocale(..)
   , MeridiemLocale(..)
-  , UtcTime(..)
   ) where
 
 import Data.Text (Text)


### PR DESCRIPTION
This PR implements a time parsing benchmark for UtcTime. Chronos does *very* well:

```
benchmarking parsing/Thyme.parseTime
time                 1.329 μs   (1.312 μs .. 1.354 μs)
                     0.996 R²   (0.992 R² .. 0.999 R²)
mean                 1.341 μs   (1.318 μs .. 1.381 μs)
std dev              101.7 ns   (69.75 ns .. 138.8 ns)
variance introduced by outliers: 82% (severely inflated)

benchmarking parsing/Time.parseTimeM
time                 2.864 μs   (2.853 μs .. 2.876 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.858 μs   (2.850 μs .. 2.874 μs)
std dev              38.22 ns   (22.48 ns .. 63.50 ns)
variance introduced by outliers: 11% (moderately inflated)

benchmarking parsing/Thyme.timeParser
time                 939.6 ns   (935.8 ns .. 943.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 932.8 ns   (930.7 ns .. 935.7 ns)
std dev              8.448 ns   (6.771 ns .. 10.39 ns)

benchmarking parsing/Chronos.parser
time                 391.0 ns   (385.7 ns .. 398.2 ns)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 388.3 ns   (385.1 ns .. 394.5 ns)
std dev              14.69 ns   (7.612 ns .. 25.32 ns)
variance introduced by outliers: 55% (severely inflated)
```