### PR TITLE
Zepto performance wins

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -5,12 +7,19 @@
 
 module Main where
 
+import qualified Data.Vector.Unboxed as UVector
 import Criterion.Main
+import Data.Int
 import Data.Maybe (fromMaybe)
 import Control.DeepSeq (($!!), NFData(..), deepseq)
 import qualified Data.ByteString.Char8 as BS8
 import Test.QuickCheck (arbitrary, generate)
 import Data.Attoparsec.ByteString.Char8 (Parser, parseOnly, char)
+import qualified Data.Attoparsec.Zepto as Z
+import Data.Foldable (traverse_)
+import Data.Word
+import Control.Monad (when)
+import Control.Applicative
 
 import qualified Data.Time as Time
 import qualified Data.Thyme as Thyme
@@ -40,6 +49,11 @@ main = do
     chronosAttoparsec =
       either error id
       . parseOnly (Chronos.parserUtf8_YmdHMS Chronos.w3c)
+    chronosZepto :: BS8.ByteString -> Chronos.Datetime
+    chronosZepto =
+      either error id
+      . Z.parse (zparserUtf8_YmdHMS Chronos.w3c)
+
 
   string <- return $!! renderIsoTime utcthyme
   bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
@@ -50,8 +64,86 @@ main = do
       , bench "Thyme.parseTime"           $ nf thymeParser       string
       , bench "Thyme.timeParser"          $ nf thymeAttoparsec   bytestring
       , bench "Chronos.parserUtf8_YmdHMS" $ nf chronosAttoparsec bytestring
+      , bench "Chronos.zeptoUtf8_YmdHMS"  $ nf chronosZepto      bytestring
       ]
     ]
+
+zparserUtf8_YmdHMS :: Chronos.DatetimeFormat -> Z.Parser Chronos.Datetime
+zparserUtf8_YmdHMS (Chronos.DatetimeFormat mdateSep msep' mtimeSep) = do
+  date <- zparserUtf8_Ymd mdateSep
+  let msep = BS8.singleton <$> msep'
+  traverse_ Z.string msep
+  time <- zparserUtf8_HMS mtimeSep
+  return (Chronos.Datetime date time)
+
+
+countZeroes :: Z.Parser Int
+countZeroes = do
+    bs <- Z.takeWhile (0x30 ==)
+    pure $!! BS8.length bs
+
+zparserUtf8_Ymd :: Maybe Char -> Z.Parser Chronos.Date
+zparserUtf8_Ymd msep' = do
+  y <- parseFixedDigitsIntBS 4
+  let msep = BS8.singleton <$> msep'
+  traverse_ Z.string msep
+  m <- parseFixedDigitsIntBS 2
+  when (m < 1 || m > 12) (fail "month must be between 1 and 12")
+  traverse_ Z.string msep
+  d <- parseFixedDigitsIntBS 2
+  when (d < 1 || d > 31) (fail "day must be between 1 and 31")
+  return (Chronos.Date (Chronos.Year y) (Chronos.Month $ m - 1) (Chronos.DayOfMonth d))
+
+zparserUtf8_HMS :: Maybe Char -> Z.Parser Chronos.TimeOfDay
+zparserUtf8_HMS msep' = do
+  h <- parseFixedDigitsIntBS 2
+  when (h > 23) (fail "hour must be between 0 and 23")
+  let msep = BS8.singleton <$> msep'
+  traverse_ Z.string msep
+  m <- parseFixedDigitsIntBS 2
+  when (m > 59) (fail "minute must be between 0 and 59")
+  traverse_ Z.string msep
+  ns <- parseSecondsAndNanosecondsUtf8
+  return (Chronos.TimeOfDay h m ns)
+
+parseFixedDigitsIntBS :: Int -> Z.Parser Int
+parseFixedDigitsIntBS n = do
+  t <- Z.take n
+  case BS8.readInt t of
+    Nothing -> fail "datetime decoding could not parse integral bytestring (a)"
+    Just (i,r) -> if BS8.null r
+      then return i
+      else fail "datetime decoding could not parse integral bytestring (b)"
+
+
+parseSecondsAndNanosecondsUtf8 :: Z.Parser Int64
+parseSecondsAndNanosecondsUtf8 = do
+  s' <- parseFixedDigitsIntBS 2
+  let s = fromIntegral s' :: Int64
+  when (s > 60) (fail "seconds must be between 0 and 60")
+  nanoseconds <-
+    ( do _ <- Z.string "."
+         numberOfZeroes <- countZeroes
+         x <- zdecimal
+         let totalDigits = countDigits x + numberOfZeroes
+             result = if totalDigits == 9
+               then x
+               else if totalDigits < 9
+                 then x * raiseTenTo (9 - totalDigits)
+                 else quot x (raiseTenTo (totalDigits - 9))
+         return (fromIntegral result)
+    ) <|> return 0
+  return (s * 1000000000 + nanoseconds)
+
+zdecimal :: Z.Parser Int64
+zdecimal = do
+    digits <- Z.takeWhile wordIsDigit
+    case BS8.readInt digits of
+      Nothing -> fail "somehow this didn't work"
+      Just (i,_) -> pure $!! fromIntegral i
+
+wordIsDigit :: Word8 -> Bool
+wordIsDigit a = 0x30 <= a && a <= 0x39
 
 instance NFData Chronos.Datetime where
   rnf (Chronos.Datetime a b) = a `deepseq` b `deepseq` ()
@@ -66,3 +158,39 @@ deriving instance NFData Chronos.DayOfMonth
 deriving instance NFData Chronos.Month
 deriving instance NFData Chronos.Year
 deriving instance NFData Chronos.Day
+
+
+countDigits :: (Integral a) => a -> Int
+countDigits v0
+  | fromIntegral v64 == v0 = go 1 v64
+  | otherwise              = goBig 1 (fromIntegral v0)
+  where v64 = fromIntegral v0
+        goBig !k (v :: Integer)
+           | v > big   = goBig (k + 19) (v `quot` big)
+           | otherwise = go k (fromIntegral v)
+        big = 10000000000000000000
+        go !k (v :: Word64)
+           | v < 10    = k
+           | v < 100   = k + 1
+           | v < 1000  = k + 2
+           | v < 1000000000000 =
+               k + if v < 100000000
+                   then if v < 1000000
+                        then if v < 10000
+                             then 3
+                             else 4 + fin v 100000
+                        else 6 + fin v 10000000
+                   else if v < 10000000000
+                        then 8 + fin v 1000000000
+                        else 10 + fin v 100000000000
+           | otherwise = go (k + 12) (v `quot` 1000000000000)
+        fin v n = if v >= n then 1 else 0
+
+raiseTenTo :: Int -> Int64
+raiseTenTo i = if i > 15
+  then 10 ^ i
+  else UVector.unsafeIndex tenRaisedToSmallPowers i
+
+
+tenRaisedToSmallPowers :: UVector.Vector Int64
+tenRaisedToSmallPowers = UVector.fromList $ map (10 ^) [0 :: Int ..15]

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -52,7 +52,7 @@ main = do
     chronosZepto :: BS8.ByteString -> Chronos.Datetime
     chronosZepto =
       either error id
-      . Z.parse (zparserUtf8_YmdHMS Chronos.w3c)
+      . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
 
   string <- return $!! renderIsoTime utcthyme
@@ -68,83 +68,6 @@ main = do
       ]
     ]
 
-zparserUtf8_YmdHMS :: Chronos.DatetimeFormat -> Z.Parser Chronos.Datetime
-zparserUtf8_YmdHMS (Chronos.DatetimeFormat mdateSep msep' mtimeSep) = do
-  date <- zparserUtf8_Ymd mdateSep
-  let msep = BS8.singleton <$> msep'
-  traverse_ Z.string msep
-  time <- zparserUtf8_HMS mtimeSep
-  return (Chronos.Datetime date time)
-
-
-countZeroes :: Z.Parser Int
-countZeroes = do
-    bs <- Z.takeWhile (0x30 ==)
-    pure $!! BS8.length bs
-
-zparserUtf8_Ymd :: Maybe Char -> Z.Parser Chronos.Date
-zparserUtf8_Ymd msep' = do
-  y <- parseFixedDigitsIntBS 4
-  let msep = BS8.singleton <$> msep'
-  traverse_ Z.string msep
-  m <- parseFixedDigitsIntBS 2
-  when (m < 1 || m > 12) (fail "month must be between 1 and 12")
-  traverse_ Z.string msep
-  d <- parseFixedDigitsIntBS 2
-  when (d < 1 || d > 31) (fail "day must be between 1 and 31")
-  return (Chronos.Date (Chronos.Year y) (Chronos.Month $ m - 1) (Chronos.DayOfMonth d))
-
-zparserUtf8_HMS :: Maybe Char -> Z.Parser Chronos.TimeOfDay
-zparserUtf8_HMS msep' = do
-  h <- parseFixedDigitsIntBS 2
-  when (h > 23) (fail "hour must be between 0 and 23")
-  let msep = BS8.singleton <$> msep'
-  traverse_ Z.string msep
-  m <- parseFixedDigitsIntBS 2
-  when (m > 59) (fail "minute must be between 0 and 59")
-  traverse_ Z.string msep
-  ns <- parseSecondsAndNanosecondsUtf8
-  return (Chronos.TimeOfDay h m ns)
-
-parseFixedDigitsIntBS :: Int -> Z.Parser Int
-parseFixedDigitsIntBS n = do
-  t <- Z.take n
-  case BS8.readInt t of
-    Nothing -> fail "datetime decoding could not parse integral bytestring (a)"
-    Just (i,r) -> if BS8.null r
-      then return i
-      else fail "datetime decoding could not parse integral bytestring (b)"
-
-
-parseSecondsAndNanosecondsUtf8 :: Z.Parser Int64
-parseSecondsAndNanosecondsUtf8 = do
-  s' <- parseFixedDigitsIntBS 2
-  let s = fromIntegral s' :: Int64
-  when (s > 60) (fail "seconds must be between 0 and 60")
-  nanoseconds <-
-    ( do _ <- Z.string "."
-         numberOfZeroes <- countZeroes
-         x <- zdecimal
-         let totalDigits = countDigits x + numberOfZeroes
-             result = if totalDigits == 9
-               then x
-               else if totalDigits < 9
-                 then x * raiseTenTo (9 - totalDigits)
-                 else quot x (raiseTenTo (totalDigits - 9))
-         return (fromIntegral result)
-    ) <|> return 0
-  return (s * 1000000000 + nanoseconds)
-
-zdecimal :: Z.Parser Int64
-zdecimal = do
-    digits <- Z.takeWhile wordIsDigit
-    case BS8.readInt digits of
-      Nothing -> fail "somehow this didn't work"
-      Just (i,_) -> pure $!! fromIntegral i
-
-wordIsDigit :: Word8 -> Bool
-wordIsDigit a = 0x30 <= a && a <= 0x39
-
 instance NFData Chronos.Datetime where
   rnf (Chronos.Datetime a b) = a `deepseq` b `deepseq` ()
 
@@ -158,39 +81,3 @@ deriving instance NFData Chronos.DayOfMonth
 deriving instance NFData Chronos.Month
 deriving instance NFData Chronos.Year
 deriving instance NFData Chronos.Day
-
-
-countDigits :: (Integral a) => a -> Int
-countDigits v0
-  | fromIntegral v64 == v0 = go 1 v64
-  | otherwise              = goBig 1 (fromIntegral v0)
-  where v64 = fromIntegral v0
-        goBig !k (v :: Integer)
-           | v > big   = goBig (k + 19) (v `quot` big)
-           | otherwise = go k (fromIntegral v)
-        big = 10000000000000000000
-        go !k (v :: Word64)
-           | v < 10    = k
-           | v < 100   = k + 1
-           | v < 1000  = k + 2
-           | v < 1000000000000 =
-               k + if v < 100000000
-                   then if v < 1000000
-                        then if v < 10000
-                             then 3
-                             else 4 + fin v 100000
-                        else 6 + fin v 10000000
-                   else if v < 10000000000
-                        then 8 + fin v 1000000000
-                        else 10 + fin v 100000000000
-           | otherwise = go (k + 12) (v `quot` 1000000000000)
-        fin v n = if v >= n then 1 else 0
-
-raiseTenTo :: Int -> Int64
-raiseTenTo i = if i > 15
-  then 10 ^ i
-  else UVector.unsafeIndex tenRaisedToSmallPowers i
-
-
-tenRaisedToSmallPowers :: UVector.Vector Int64
-tenRaisedToSmallPowers = UVector.fromList $ map (10 ^) [0 :: Int ..15]

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -90,6 +90,7 @@ benchmark bench
     , QuickCheck
     , thyme
     , time
+    , vector
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -1606,8 +1606,8 @@ zeptoUtf8_YmdHMS (DatetimeFormat mdateSep msep' mtimeSep) = do
 
 zeptoCountZeroes :: Z.Parser Int
 zeptoCountZeroes = do
-    bs <- Z.takeWhile (0x30 ==)
-    pure $! BC.length bs
+  bs <- Z.takeWhile (0x30 ==)
+  pure $! BC.length bs
 
 zeptoUtf8_Ymd :: Maybe Char -> Z.Parser Chronos.Date
 zeptoUtf8_Ymd msep' = do
@@ -1663,10 +1663,10 @@ zeptoSecondsAndNanosecondsUtf8 = do
 
 zdecimal :: Z.Parser Int64
 zdecimal = do
-    digits <- Z.takeWhile wordIsDigit
-    case BC.readInt digits of
-      Nothing -> fail "somehow this didn't work"
-      Just (i,_) -> pure $! fromIntegral i
+  digits <- Z.takeWhile wordIsDigit
+  case BC.readInt digits of
+    Nothing -> fail "somehow this didn't work"
+    Just (i,_) -> pure $! fromIntegral i
 
 wordIsDigit :: Word8 -> Bool
 wordIsDigit a = 0x30 <= a && a <= 0x39


### PR DESCRIPTION
I've always wondered about Zepto. Turns out it is fast:

```
Benchmark bench: RUNNING...
benchmarking parsing/Time.parseTimeM
time                 8.935 μs   (8.447 μs .. 9.549 μs)
                     0.983 R²   (0.972 R² .. 0.998 R²)
mean                 8.538 μs   (8.367 μs .. 8.900 μs)
std dev              764.0 ns   (464.9 ns .. 1.190 μs)
variance introduced by outliers: 84% (severely inflated)

benchmarking parsing/Thyme.parseTime
time                 1.770 μs   (1.678 μs .. 1.851 μs)
                     0.989 R²   (0.985 R² .. 0.996 R²)
mean                 1.675 μs   (1.641 μs .. 1.720 μs)
std dev              125.4 ns   (83.81 ns .. 171.0 ns)
variance introduced by outliers: 81% (severely inflated)

benchmarking parsing/Thyme.timeParser
time                 1.042 μs   (1.009 μs .. 1.088 μs)
                     0.990 R²   (0.985 R² .. 0.996 R²)
mean                 1.106 μs   (1.067 μs .. 1.164 μs)
std dev              166.2 ns   (108.8 ns .. 254.1 ns)
variance introduced by outliers: 95% (severely inflated)

benchmarking parsing/Chronos.parserUtf8_YmdHMS
time                 367.0 ns   (363.1 ns .. 371.9 ns)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 373.1 ns   (367.2 ns .. 384.6 ns)
std dev              26.70 ns   (16.93 ns .. 42.87 ns)
variance introduced by outliers: 82% (severely inflated)

benchmarking parsing/Chronos.zeptoUtf8_YmdHMS
time                 218.1 ns   (216.1 ns .. 221.7 ns)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 220.3 ns   (218.2 ns .. 224.3 ns)
std dev              9.417 ns   (4.888 ns .. 14.93 ns)
variance introduced by outliers: 62% (severely inflated)

Benchmark bench: FINISH
```