### PR TITLE
Add benchmarks for pretty-print

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -59,14 +59,18 @@ main = do
     hms              = "%%H:%M:%S."
     timePretty       = Time.formatTime Time.defaultTimeLocale
     thymePretty      = Thyme.formatTime Thyme.defaultTimeLocale
-    chronosPrettyHMS = toLazyText . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
-    chronosPrettyDmy = toLazyText . Chronos.builder_Dmy (Just ':')
-
+    chronosPrettyDmy = toLazyText
+      . Chronos.builder_Dmy (Just ':')
+      . Chronos.datetimeDate
+      . Chronos.timeToDatetime
+    chronosPrettyHMS = toLazyText
+      . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
+      . Chronos.datetimeTime
+      . Chronos.timeToDatetime
 
   timeTime  <- Time.getCurrentTime
   thymeTime <- Thyme.getCurrentTime
-  chronosDate <- Chronos.dayToDate <$> Chronos.today
-  chronosTime <- (Chronos.datetimeTime . Chronos.timeToDatetime) <$> Chronos.now
+  chronosTime <- Chronos.now
 
   string <- return $!! renderIsoTime utcthyme
   bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
@@ -84,7 +88,7 @@ main = do
       [ bgroup "dmy"
         [ bench "Time.formatTime"     $ nf (timePretty dmy)  timeTime
         , bench "Thyme.formatTime"    $ nf (thymePretty dmy) thymeTime
-        , bench "Chronos.builder_Dmy" $ nf chronosPrettyDmy  chronosDate
+        , bench "Chronos.builder_Dmy" $ nf chronosPrettyDmy  chronosTime
         ]
       , bgroup "HMS"
         [ bench "Time.formatTime"     $ nf (timePretty hms)  timeTime

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -20,6 +20,7 @@ import Data.Foldable (traverse_)
 import Data.Word
 import Control.Monad (when)
 import Control.Applicative
+import Data.Text.Lazy.Builder (toLazyText)
 
 import qualified Data.Time as Time
 import qualified Data.Thyme as Thyme
@@ -54,6 +55,13 @@ main = do
       either error id
       . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
+    timePretty = Time.formatTime Time.defaultTimeLocale "%d:%m:%y."
+    thymePretty = Thyme.formatTime Thyme.defaultTimeLocale "%d:%m:%y."
+    chronosPretty = toLazyText . Chronos.builder_Dmy (Just ':')
+
+  timeTime  <- Time.getCurrentTime
+  thymeTime <- Thyme.getCurrentTime
+  chronosDate <- Chronos.dayToDate <$> Chronos.today
 
   string <- return $!! renderIsoTime utcthyme
   bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
@@ -65,6 +73,12 @@ main = do
       , bench "Thyme.timeParser"          $ nf thymeAttoparsec   bytestring
       , bench "Chronos.parserUtf8_YmdHMS" $ nf chronosAttoparsec bytestring
       , bench "Chronos.zeptoUtf8_YmdHMS"  $ nf chronosZepto      bytestring
+      ]
+
+    , bgroup "prettyPrint"
+      [ bench "Time.formatTime"     $ nf timePretty    timeTime
+      , bench "Thyme.formatTime"    $ nf thymePretty   thymeTime
+      , bench "Chronos.builder_Dmy" $ nf chronosPretty chronosDate
       ]
     ]
 

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -55,13 +55,18 @@ main = do
       either error id
       . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
-    timePretty = Time.formatTime Time.defaultTimeLocale "%d:%m:%y."
-    thymePretty = Thyme.formatTime Thyme.defaultTimeLocale "%d:%m:%y."
-    chronosPretty = toLazyText . Chronos.builder_Dmy (Just ':')
+    timePrettyDmy    = Time.formatTime Time.defaultTimeLocale "%d:%m:%y."
+    thymePrettyDmy   = Thyme.formatTime Thyme.defaultTimeLocale "%d:%m:%y."
+    chronosPrettyDmy = toLazyText . Chronos.builder_Dmy (Just ':')
+
+    timePrettyHMS    = Time.formatTime Time.defaultTimeLocale "%%H:%M:%S."
+    thymePrettyHMS   = Thyme.formatTime Thyme.defaultTimeLocale "%H:%M:%S."
+    chronosPrettyHMS = toLazyText . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
 
   timeTime  <- Time.getCurrentTime
   thymeTime <- Thyme.getCurrentTime
   chronosDate <- Chronos.dayToDate <$> Chronos.today
+  chronosTime <- (Chronos.datetimeTime . Chronos.timeToDatetime) <$> Chronos.now
 
   string <- return $!! renderIsoTime utcthyme
   bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
@@ -76,9 +81,16 @@ main = do
       ]
 
     , bgroup "prettyPrint"
-      [ bench "Time.formatTime"     $ nf timePretty    timeTime
-      , bench "Thyme.formatTime"    $ nf thymePretty   thymeTime
-      , bench "Chronos.builder_Dmy" $ nf chronosPretty chronosDate
+      [ bgroup "dmy"
+        [ bench "Time.formatTime"     $ nf timePrettyDmy    timeTime
+        , bench "Thyme.formatTime"    $ nf thymePrettyDmy   thymeTime
+        , bench "Chronos.builder_Dmy" $ nf chronosPrettyDmy chronosDate
+        ]
+      , bgroup "HMS"
+        [ bench "Time.formatTime"     $ nf timePrettyHMS    timeTime
+        , bench "Thyme.formatTime"    $ nf thymePrettyHMS   thymeTime
+        , bench "Chronos.builder_HMS" $ nf chronosPrettyHMS chronosTime
+        ]
       ]
     ]
 

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -55,12 +55,14 @@ main = do
       either error id
       . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
-    timePrettyDmy    = Time.formatTime Time.defaultTimeLocale "%d:%m:%y."
-    thymePrettyDmy   = Thyme.formatTime Thyme.defaultTimeLocale "%d:%m:%y."
+    dmy              = "%d:%m:%y."
+    timePrettyDmy    = Time.formatTime Time.defaultTimeLocale dmy
+    thymePrettyDmy   = Thyme.formatTime Thyme.defaultTimeLocale dmy
     chronosPrettyDmy = toLazyText . Chronos.builder_Dmy (Just ':')
 
-    timePrettyHMS    = Time.formatTime Time.defaultTimeLocale "%%H:%M:%S."
-    thymePrettyHMS   = Thyme.formatTime Thyme.defaultTimeLocale "%H:%M:%S."
+    hms              = "%%H:%M:%S."
+    timePrettyHMS    = Time.formatTime Time.defaultTimeLocale hms
+    thymePrettyHMS   = Thyme.formatTime Thyme.defaultTimeLocale hms
     chronosPrettyHMS = toLazyText . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
 
   timeTime  <- Time.getCurrentTime

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -56,14 +56,12 @@ main = do
       . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
     dmy              = "%d:%m:%y."
-    timePrettyDmy    = Time.formatTime Time.defaultTimeLocale dmy
-    thymePrettyDmy   = Thyme.formatTime Thyme.defaultTimeLocale dmy
+    hms              = "%%H:%M:%S."
+    timePretty       = Time.formatTime Time.defaultTimeLocale
+    thymePretty      = Thyme.formatTime Thyme.defaultTimeLocale
+    chronosPrettyHMS = toLazyText . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
     chronosPrettyDmy = toLazyText . Chronos.builder_Dmy (Just ':')
 
-    hms              = "%%H:%M:%S."
-    timePrettyHMS    = Time.formatTime Time.defaultTimeLocale hms
-    thymePrettyHMS   = Thyme.formatTime Thyme.defaultTimeLocale hms
-    chronosPrettyHMS = toLazyText . Chronos.builder_HMS Chronos.SubsecondPrecisionAuto (Just ':')
 
   timeTime  <- Time.getCurrentTime
   thymeTime <- Thyme.getCurrentTime
@@ -84,14 +82,14 @@ main = do
 
     , bgroup "prettyPrint"
       [ bgroup "dmy"
-        [ bench "Time.formatTime"     $ nf timePrettyDmy    timeTime
-        , bench "Thyme.formatTime"    $ nf thymePrettyDmy   thymeTime
-        , bench "Chronos.builder_Dmy" $ nf chronosPrettyDmy chronosDate
+        [ bench "Time.formatTime"     $ nf (timePretty dmy)  timeTime
+        , bench "Thyme.formatTime"    $ nf (thymePretty dmy) thymeTime
+        , bench "Chronos.builder_Dmy" $ nf chronosPrettyDmy  chronosDate
         ]
       , bgroup "HMS"
-        [ bench "Time.formatTime"     $ nf timePrettyHMS    timeTime
-        , bench "Thyme.formatTime"    $ nf thymePrettyHMS   thymeTime
-        , bench "Chronos.builder_HMS" $ nf chronosPrettyHMS chronosTime
+        [ bench "Time.formatTime"     $ nf (timePretty hms)  timeTime
+        , bench "Thyme.formatTime"    $ nf (thymePretty hms) thymeTime
+        , bench "Chronos.builder_HMS" $ nf chronosPrettyHMS  chronosTime
         ]
       ]
     ]

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -91,6 +91,7 @@ benchmark bench
     , thyme
     , time
     , vector
+    , text
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
This is related to #22 

I am not sure at all about the `Chronos` use, in particular where to put the `dayToDate` or `Chronos.timeToDatetime` conversion . Do we need to take into account these conversions in the benchmark time ?

Otherwise, I am benchmarking two pretty functions:
* Dmy: or Days Month Year
* HMS: or Hour Minutes Seconds