### PR TITLE
ghcjs now function

### DIFF
--- a/src/Chronos/Internal/CTimespec.hs
+++ b/src/Chronos/Internal/CTimespec.hs
@@ -9,12 +9,11 @@ import Foreign
 import Foreign.C
 
 #ifdef ghcjs_HOST_OS
-
--- foreign import javascript unsafe "Date.now()" currentSeconds :: IO Int64
-
+foreign import javascript unsafe "Date.now()" currentSeconds :: IO Double
 getPosixNanoseconds :: IO Int64
-getPosixNanoseconds = return 0
-
+getPosixNanoseconds = do 
+  x <- currentSeconds 
+  pure $ fromIntegral $ 1000000 * (round x)
 #else
 
 data CTimespec = CTimespec


### PR DESCRIPTION
getPosixNanoseconds returns the value of Date.now()
this loses 6 digits of percision, but is better than 'return 0'