### PR TITLE
Bump semigroups bound.

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -64,7 +64,7 @@ library
     , clock >= 0.7 && < 0.9
     , hashable >= 1.2 && < 1.4
     , primitive >= 0.6.4 && < 0.8
-    , semigroups >= 0.16 && < 0.19
+    , semigroups >= 0.16 && < 0.20
     , text >= 1.2 && < 1.3
     , torsor >= 0.1 && < 0.2
     , vector >= 0.11 && < 0.13


### PR DESCRIPTION
I was able to build without difficulty on the latest `semigroups` (0.19.1).