### PR TITLE
drop clock on newer GHCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1: [2019.11.09]
+-----------------
+* Drop dependency of `clock` on GHC 8.6+.
+* Remove `stopwatchWith(_)` on GHC 8.6+.
+
 1.0.9: [2019.11.09]
 -------------------
 * Add `TimeParts` for custom formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----------------
 * Drop dependency of `clock` on GHC 8.6+.
 * Remove `stopwatchWith(_)` on GHC 8.6+.
+* Deprecate `stopwatchWith(_)` on GHC <8.6.
 
 1.0.9: [2019.11.09]
 -------------------

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   chronos
 version:
-  1.0.9
+  1.1
 synopsis:
   A performant time library
 description:
@@ -61,7 +61,6 @@ library
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.9 && < 5
     , bytestring >= 0.10 && < 0.11
-    , clock >= 0.7 && < 0.9
     , hashable >= 1.2 && < 1.4
     , primitive >= 0.6.4 && < 0.8
     , semigroups >= 0.16 && < 0.20
@@ -70,6 +69,8 @@ library
     , vector >= 0.11 && < 0.13
   if os(windows)
     build-depends: Win32 >= 2.2 && < 2.9
+  if impl(ghc < 8.4)
+    build-depends: clock >= 0.7 && < 0.9
   default-language:
     Haskell2010
   c-sources:

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -535,6 +535,7 @@ stopwatchWith c action = do
   a <- action >>= evaluate
   end <- CLK.getTime c
   pure (timeSpecToTimespan (CLK.diffTimeSpec end start),a)
+{-# DEPRECATED stopwatchWith "stopwatchWith will be removed in a future majour version" #-}
 
 -- | Variant of 'stopwatch_' that accepts a clock type.
 stopwatchWith_ :: CLK.Clock -> IO a -> IO Timespan
@@ -543,6 +544,7 @@ stopwatchWith_ c action = do
   _ <- action
   end <- CLK.getTime c
   pure (timeSpecToTimespan (CLK.diffTimeSpec end start))
+{-# DEPRECATED stopwatchWith_ "stopwatchWith_ will be removed in a future majour version" #-}
 
 timeSpecToTimespan :: CLK.TimeSpec -> Timespan
 timeSpecToTimespan (CLK.TimeSpec s ns) = Timespan (s * 1000000000 + ns)


### PR DESCRIPTION
this PR drops clock on newer GHCs, in favour of getMonotonicTimeNSec.

resolves #29 