### PR TITLE
enable RecordWildCards in Chronos.hs

### DIFF
--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -5,6 +5,7 @@
   , GeneralizedNewtypeDeriving
   , MultiParamTypeClasses
   , OverloadedStrings
+  , RecordWildCards
   , ScopedTypeVariables
   , TypeFamilies
   , TypeInType


### PR DESCRIPTION
Necessary since #36 on Windows, at least in GHC 8.6.3