### PR TITLE
Adds Lenient versions of Datetime parsers and decoders

### DIFF
--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -1520,8 +1520,8 @@ parser_MdyHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with either no separators or any non-numeric ascii character as
---   separators.
+--   encoded with either no separators or any non-numeric ascii character for
+--   each separator.
 parser_MdyHMS_lenient :: Parser Datetime
 parser_MdyHMS_lenient = do
   mdate <- optional $ parser_Mdy Nothing

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -958,8 +958,8 @@ parser_Ymd msep = do
   when (d < 1 || d > 31) (fail "day must be between 1 and 31")
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
--- | Parse a Year\/Month\/Day-encoded 'Date' that uses any non-numeric ascii
---   character as separators.
+-- | Parse a Year\/Month\/Day-encoded 'Date' that either has no separators or
+--   uses any non-numeric ascii character for each separator.
 parser_Ymd_lenient :: Parser Date
 parser_Ymd_lenient = do
   y <- parseFixedDigits 4
@@ -970,8 +970,8 @@ parser_Ymd_lenient = do
   d <- parseFixedDigits 2
   when (d < 1 || d > 31) (fail "day must be between 1 and 31")
   case (sep1, sep2) of
-    (Nothing, Just _) -> fail "Seperators must all exist or not"
-    (Just _, Nothing) -> fail "Seperators must all exist or not"
+    (Nothing, Just _) -> fail "Separators must all exist or not"
+    (Just _, Nothing) -> fail "Separators must all exist or not"
     _ -> pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Month\/Day\/Year-encoded 'Date' that uses the
@@ -987,8 +987,8 @@ parser_Mdy msep = do
   y <- parseFixedDigits 4
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
--- | Parse a Month\/Day\/Year-encoded 'Date' that uses any non-numeric character
--- as separator.
+-- | Parse a Month\/Day\/Year-encoded 'Date' that either has no separators or
+-- uses any non-numeric character for each separator.
 parser_Mdy_lenient :: Parser Date
 parser_Mdy_lenient = do
   m <- parseFixedDigits 2
@@ -999,8 +999,8 @@ parser_Mdy_lenient = do
   sep2 <- optional parserLenientSeparator
   y <- parseFixedDigits 4
   case (sep1, sep2) of
-    (Nothing, Just _) -> fail "Seperators must all exist or not"
-    (Just _, Nothing) -> fail "Seperators must all exist or not"
+    (Nothing, Just _) -> fail "Separators must all exist or not"
+    (Just _, Nothing) -> fail "Separators must all exist or not"
     _ -> pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Day\/Month\/Year-encoded 'Date' that uses the
@@ -1016,8 +1016,8 @@ parser_Dmy msep = do
   y <- parseFixedDigits 4
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
--- | Parse a Day\/Month\/Year-encoded 'Date' that uses any non-numeric character
--- as separator
+-- | Parse a Day\/Month\/Year-encoded 'Date' that either has no separators or
+--   uses any non-numeric ascii character for each separator.
 parser_Dmy_lenient :: Parser Date
 parser_Dmy_lenient = do
   d <- parseFixedDigits 2
@@ -1028,8 +1028,8 @@ parser_Dmy_lenient = do
   sep2 <- optional parserLenientSeparator
   y <- parseFixedDigits 4
   case (sep1, sep2) of
-    (Nothing, Just _) -> fail "Seperators must all exist or not"
-    (Just _, Nothing) -> fail "Seperators must all exist or not"
+    (Nothing, Just _) -> fail "Separators must all exist or not"
+    (Just _, Nothing) -> fail "Separators must all exist or not"
     _ -> pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Given a 'Date' and a separator, construct a 'ByteString' 'BB.Builder'
@@ -1117,8 +1117,8 @@ parser_HMS msep = do
 parserLenientSeparator :: Parser ()
 parserLenientSeparator = AT.satisfy (not . isDigit) *> pure ()
 
--- | Parse an Hour\/Minute\/Second-encoded 'TimeOfDay' that uses
---   any given non-numeric char separator.
+-- | Parse an Hour\/Minute\/Second-encoded 'TimeOfDay' that either has no
+--   separators or uses any given non-numeric character for each separator.
 parser_HMS_lenient :: Parser TimeOfDay
 parser_HMS_lenient = do
   h <- parseFixedDigits 2
@@ -1165,8 +1165,8 @@ parser_HMS_opt_S msep = do
           pure (TimeOfDay h m ns)
         else pure (TimeOfDay h m 0)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as separators:
+-- | Parses text that is formatted as either of the following with either no
+-- separators or any non-numeric ascii characters for each separator:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1402,8 +1402,8 @@ decode_YmdHMS format =
   either (const Nothing) Just . AT.parseOnly (parser_YmdHMS format)
 
 -- | Decode a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with the given 'DatetimeFormat' with any
---   non-numeric ascii character as separators.
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator.
 decode_YmdHMS_lenient :: Text -> Maybe Datetime
 decode_YmdHMS_lenient =
   either (const Nothing) Just . AT.parseOnly parser_YmdHMS_lenient
@@ -1432,8 +1432,9 @@ parser_DmyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   time <- parser_HMS_opt_S mtimeSep
   pure (Datetime date time)
 
--- | Parses text this is formatted with any non-numeric ascii characters as
--- separators, such as:
+-- | Parse a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator, such as:
 --
 -- 01-05-2017T23:13:05
 -- 01-05-2017 23:13:05
@@ -1446,8 +1447,9 @@ parser_DmyHMS_lenient = do
     Just date -> Datetime date <$> parser_HMS Nothing
     Nothing -> Datetime <$> parser_Dmy_lenient <* parserLenientSeparator <*> parser_HMS_lenient
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as separators:
+-- | Parse a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1463,8 +1465,8 @@ parser_DmyHMS_opt_S_lenient = do
     Nothing -> Datetime <$> parser_Dmy_lenient <* parserLenientSeparator <*> parser_HMS_opt_S_lenient
 
 -- | Decodes Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
--- 'Text' that is encoded with any non-numeric ascii characters as separators,
--- such as:
+-- 'Text' that is encoded with either no separators or any non-numeric ascii
+-- characters as separators, such as:
 --
 -- 2017-01-05T23:13:05
 -- 2017-01-05 23:13:05
@@ -1479,7 +1481,9 @@ decode_DmyHMS :: DatetimeFormat -> Text -> Maybe Datetime
 decode_DmyHMS format =
   either (const Nothing) Just . AT.parseOnly (parser_DmyHMS format)
 
--- | Parses text that is formatted as either of the following:
+-- | Decode a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with with the given 'DatetimeFormat' and with
+--   either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1491,8 +1495,9 @@ decode_DmyHMS_opt_S :: DatetimeFormat -> Text -> Maybe Datetime
 decode_DmyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_DmyHMS_opt_S format)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as separators:
+-- | Decode a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1515,7 +1520,8 @@ parser_MdyHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with any non-numeric ascii characters as separators.
+--   encoded with either no separators or any non-numeric ascii character as
+--   separators.
 parser_MdyHMS_lenient :: Parser Datetime
 parser_MdyHMS_lenient = do
   mdate <- optional $ parser_Mdy Nothing
@@ -1523,7 +1529,9 @@ parser_MdyHMS_lenient = do
     Just date -> Datetime date <$> parser_HMS Nothing
     Nothing -> Datetime <$> parser_Mdy_lenient <* parserLenientSeparator <*> parser_HMS_lenient
 
--- | Parses text that is formatted as either of the following:
+-- | Parse a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with with the given 'DatetimeFormat' and with
+--   either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1537,8 +1545,9 @@ parser_MdyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   time <- parser_HMS_opt_S mtimeSep
   pure (Datetime date time)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as separators:
+-- | Parse a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1559,13 +1568,15 @@ decode_MdyHMS format =
   either (const Nothing) Just . AT.parseOnly (parser_MdyHMS format)
 
 -- | Decode a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with the given 'DatetimeFormat' with any
---   non-numeric ascii characters as separators.
+--   'Text' with either no separators or any non-numeric ascii character for
+--   each separator.
 decode_MdyHMS_lenient :: Text -> Maybe Datetime
 decode_MdyHMS_lenient =
   either (const Nothing) Just . AT.parseOnly parser_MdyHMS_lenient
 
--- | Parses text that is formatted as either of the following:
+-- | Decode a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with the given 'DatetimeFormat' and with either of
+--   the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1576,8 +1587,9 @@ decode_MdyHMS_opt_S :: DatetimeFormat -> Text -> Maybe Datetime
 decode_MdyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_MdyHMS_opt_S format)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii character as separators:
+-- | Parse a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' with either no separators or any non-numeric ascii character for
+--   each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1598,7 +1610,8 @@ parser_YmdHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with any non-numeric ascii characters as separators.
+--   encoded with either no separators or any non-numeric ascii character for
+--   each separator.
 parser_YmdHMS_lenient :: Parser Datetime
 parser_YmdHMS_lenient = do
   mdate <- optional $ parser_Ymd Nothing
@@ -1606,7 +1619,9 @@ parser_YmdHMS_lenient = do
     Just date -> Datetime date <$> parser_HMS Nothing
     Nothing -> Datetime <$> parser_Ymd_lenient <* parserLenientSeparator <*> parser_HMS_lenient
 
--- | Parses text that is formatted as either of the following:
+-- | Parses a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with the given 'DatetimeFormat' and with either of
+--   the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1621,8 +1636,9 @@ parser_YmdHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   time <- parser_HMS_opt_S mtimeSep
   pure (Datetime date time)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as separators:
+-- | Parses a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1637,7 +1653,9 @@ parser_YmdHMS_opt_S_lenient = do
     Just date -> Datetime date <$> parser_HMS_opt_S Nothing
     Nothing -> Datetime <$> parser_Ymd_lenient <* parserLenientSeparator <*> parser_HMS_opt_S_lenient
 
--- | Parses text that is formatted as either of the following:
+-- | Decode a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with the given 'DatetimeFormat' and with either of
+--   the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1649,8 +1667,9 @@ decode_YmdHMS_opt_S :: DatetimeFormat -> Text -> Maybe Datetime
 decode_YmdHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_YmdHMS_opt_S format)
 
--- | Parses text that is formatted as either of the following with any
--- non-numeric ascii character as separators:
+-- | Decode a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
+--   'Text' that was encoded with either no separators or any non-numeric ascii
+--   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1662,19 +1681,21 @@ decode_YmdHMS_opt_S_lenient :: Text -> Maybe Datetime
 decode_YmdHMS_opt_S_lenient =
   either (const Nothing) Just . AT.parseOnly parser_YmdHMS_opt_S_lenient
 
--- | Parses text that is formatted Year\/Month\/Day,Hour\/Minute\/Second with
--- the seconds as optional and any non-numeric ascii character as separators.
+-- | Parses a 'Datetime' from 'Text' that was encoded with any of the following formats and with
+-- either no separators or any non-numeric ascii character for each separator.
 --
--- * @%Y:%M%D %H:%M@
--- * @%Y:%M%D %H:%M:%S@
--- * @%D:%M%Y %H:%M@
--- * @%D:%M%Y %H:%M:%S@
+-- * @%Y-%M-%D %H:%M@
+-- * @%Y-%M-%D %H:%M:%S@
+-- * @%D-%M-%Y %H:%M@
+-- * @%D-%M-%Y %H:%M:%S@
+-- * @%M-%D-%Y %H:%M@
+-- * @%M-%D-%Y %H:%M:%S@
 --
 -- That is, the seconds and subseconds part is optional. If it is not provided,
 -- it is assumed to be zero. Note that this is the least performant parser due
 -- to backtracking
 parser_lenient :: Parser Datetime
-parser_lenient = parser_YmdHMS_opt_S_lenient <|> parser_DmyHMS_opt_S_lenient
+parser_lenient = parser_YmdHMS_opt_S_lenient <|> parser_DmyHMS_opt_S_lenient <|> parser_MdyHMS_opt_S_lenient
 
 -- | Parses text that was encoded in DMY, YMD, or MDY format with optional
 -- seconds and any non-numeric ascii character as separators.

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -119,8 +119,10 @@ module Chronos
   , builder_Dmy
   , builder_HMS
   , parser_Ymd
+  , parser_Ymd_lenient
   , parser_Mdy
   , parser_Dmy
+  , parser_Dmy_lenient
     -- *** UTF-8 ByteString
   , builderUtf8_Ymd
   , parserUtf8_Ymd
@@ -151,9 +153,13 @@ module Chronos
   , encode_YmdHMS
   , encode_YmdIMS_p
   , parser_DmyHMS
+  , parser_DmyHMS_lenient
   , parser_YmdHMS
+  , parser_YmdHMS_lenient
   , parser_YmdHMS_opt_S
+  , parser_YmdHMS_opt_S_lenient
   , parser_DmyHMS_opt_S
+  , parser_DmyHMS_opt_S_lenient
   , decode_DmyHMS
   , decode_YmdHMS
   , decode_YmdHMS_opt_S
@@ -1078,7 +1084,6 @@ parserLenientSeperator = AT.peekChar >>= \mc ->
     Just c -> if isDigit c
       then pure ()
       else AT.anyChar >> pure ()
-
 
 -- | Parse an Hour\/Minute\/Second-encoded 'TimeOfDay' that uses
 --   any given non-numeric char seperator.

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -959,14 +959,14 @@ parser_Ymd msep = do
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Year\/Month\/Day-encoded 'Date' that uses any non-numeric ascii
---   character as seperators.
+--   character as separators.
 parser_Ymd_lenient :: Parser Date
 parser_Ymd_lenient = do
   y <- parseFixedDigits 4
-  parserLenientSeperator
+  parserLenientSeparator
   m <- parseFixedDigits 2
   when (m < 1 || m > 12) (fail "month must be between 1 and 12")
-  parserLenientSeperator
+  parserLenientSeparator
   d <- parseFixedDigits 2
   when (d < 1 || d > 31) (fail "day must be between 1 and 31")
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
@@ -985,15 +985,15 @@ parser_Mdy msep = do
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Month\/Day\/Year-encoded 'Date' that uses any non-numeric character
--- as seperator.
+-- as separator.
 parser_Mdy_lenient :: Parser Date
 parser_Mdy_lenient = do
   m <- parseFixedDigits 2
   when (m < 1 || m > 12) (fail "month must be between 1 and 12")
-  parserLenientSeperator
+  parserLenientSeparator
   d <- parseFixedDigits 2
   when (d < 1 || d > 31) (fail "day must be between 1 and 31")
-  parserLenientSeperator
+  parserLenientSeparator
   y <- parseFixedDigits 4
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
@@ -1011,15 +1011,15 @@ parser_Dmy msep = do
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Day\/Month\/Year-encoded 'Date' that uses any non-numeric character
--- as seperator
+-- as separator
 parser_Dmy_lenient :: Parser Date
 parser_Dmy_lenient = do
   d <- parseFixedDigits 2
   when (d < 1 || d > 31) (fail "day must be between 1 and 31")
-  parserLenientSeperator
+  parserLenientSeparator
   m <- parseFixedDigits 2
   when (m < 1 || m > 12) (fail "month must be between 1 and 12")
-  parserLenientSeperator
+  parserLenientSeparator
   y <- parseFixedDigits 4
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
@@ -1105,8 +1105,8 @@ parser_HMS msep = do
   ns <- parseSecondsAndNanoseconds
   pure (TimeOfDay h m ns)
 
-parserLenientSeperator :: Parser ()
-parserLenientSeperator = AT.peekChar >>= \mc ->
+parserLenientSeparator :: Parser ()
+parserLenientSeparator = AT.peekChar >>= \mc ->
   case mc of
     Nothing -> pure ()
     Just c -> if isDigit c
@@ -1114,15 +1114,15 @@ parserLenientSeperator = AT.peekChar >>= \mc ->
       else AT.anyChar >> pure ()
 
 -- | Parse an Hour\/Minute\/Second-encoded 'TimeOfDay' that uses
---   any given non-numeric char seperator.
+--   any given non-numeric char separator.
 parser_HMS_lenient :: Parser TimeOfDay
 parser_HMS_lenient = do
   h <- parseFixedDigits 2
   when (h > 23) (fail "hour must be between 0 and 23")
-  parserLenientSeperator
+  parserLenientSeparator
   m <- parseFixedDigits 2
   when (m > 59) (fail "minute must be between 0 and 59")
-  parserLenientSeperator
+  parserLenientSeparator
   ns <- parseSecondsAndNanoseconds
   pure (TimeOfDay h m ns)
 
@@ -1162,7 +1162,7 @@ parser_HMS_opt_S msep = do
         else pure (TimeOfDay h m 0)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as seperators:
+-- non-numeric ascii characters as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1174,7 +1174,7 @@ parser_HMS_opt_S_lenient :: Parser TimeOfDay
 parser_HMS_opt_S_lenient = do
   h <- parseFixedDigits 2
   when (h > 23) (fail "hour must be between 0 and 23")
-  parserLenientSeperator
+  parserLenientSeparator
   m <- parseFixedDigits 2
   when (m > 59) (fail "minute must be between 0 and 59")
   mc <- AT.peekChar
@@ -1399,7 +1399,7 @@ decode_YmdHMS format =
 
 -- | Decode a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' from
 --   'Text' that was encoded with the given 'DatetimeFormat' with any
---   non-numeric ascii character as seperators.
+--   non-numeric ascii character as separators.
 decode_YmdHMS_lenient :: Text -> Maybe Datetime
 decode_YmdHMS_lenient =
   either (const Nothing) Just . AT.parseOnly parser_YmdHMS_lenient
@@ -1429,7 +1429,7 @@ parser_DmyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses text this is formatted with any non-numeric ascii characters as
--- seperators, such as:
+-- separators, such as:
 --
 -- 2017-01-05T23:13:05
 -- 2017-01-05 23:13:05
@@ -1438,12 +1438,12 @@ parser_DmyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
 parser_DmyHMS_lenient :: Parser Datetime
 parser_DmyHMS_lenient = do
   date <- parser_Dmy_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_lenient
   pure (Datetime date time)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as seperators:
+-- non-numeric ascii characters as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1454,12 +1454,12 @@ parser_DmyHMS_lenient = do
 parser_DmyHMS_opt_S_lenient :: Parser Datetime
 parser_DmyHMS_opt_S_lenient = do
   date <- parser_Dmy_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_opt_S_lenient
   pure (Datetime date time)
 
 -- | Decodes Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
--- 'Text' that is encoded with any non-numeric ascii characters as seperators,
+-- 'Text' that is encoded with any non-numeric ascii characters as separators,
 -- such as:
 --
 -- 2017-01-05T23:13:05
@@ -1488,7 +1488,7 @@ decode_DmyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_DmyHMS_opt_S format)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as seperators:
+-- non-numeric ascii characters as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1511,11 +1511,11 @@ parser_MdyHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with any non-numeric ascii characters as seperators.
+--   encoded with any non-numeric ascii characters as separators.
 parser_MdyHMS_lenient :: Parser Datetime
 parser_MdyHMS_lenient = do
   date <- parser_Mdy_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_lenient
   pure (Datetime date time)
 
@@ -1534,7 +1534,7 @@ parser_MdyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as seperators:
+-- non-numeric ascii characters as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1544,7 +1544,7 @@ parser_MdyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
 parser_MdyHMS_opt_S_lenient :: Parser Datetime
 parser_MdyHMS_opt_S_lenient = do
   date <- parser_Mdy_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_opt_S_lenient
   pure (Datetime date time)
 
@@ -1556,7 +1556,7 @@ decode_MdyHMS format =
 
 -- | Decode a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
 --   'Text' that was encoded with the given 'DatetimeFormat' with any
---   non-numeric ascii characters as seperators.
+--   non-numeric ascii characters as separators.
 decode_MdyHMS_lenient :: Text -> Maybe Datetime
 decode_MdyHMS_lenient =
   either (const Nothing) Just . AT.parseOnly parser_MdyHMS_lenient
@@ -1573,7 +1573,7 @@ decode_MdyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_MdyHMS_opt_S format)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii character as seperators:
+-- non-numeric ascii character as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1594,11 +1594,11 @@ parser_YmdHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with any non-numeric ascii characters as seperators.
+--   encoded with any non-numeric ascii characters as separators.
 parser_YmdHMS_lenient :: Parser Datetime
 parser_YmdHMS_lenient = do
   date <- parser_Ymd_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_lenient
   pure (Datetime date time)
 
@@ -1618,7 +1618,7 @@ parser_YmdHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii characters as seperators:
+-- non-numeric ascii characters as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1629,7 +1629,7 @@ parser_YmdHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
 parser_YmdHMS_opt_S_lenient :: Parser Datetime
 parser_YmdHMS_opt_S_lenient = do
   date <- parser_Ymd_lenient
-  parserLenientSeperator
+  parserLenientSeparator
   time <- parser_HMS_opt_S_lenient
   pure (Datetime date time)
 
@@ -1646,7 +1646,7 @@ decode_YmdHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_YmdHMS_opt_S format)
 
 -- | Parses text that is formatted as either of the following with any
--- non-numeric ascii character as seperators:
+-- non-numeric ascii character as separators:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1659,7 +1659,7 @@ decode_YmdHMS_opt_S_lenient =
   either (const Nothing) Just . AT.parseOnly parser_YmdHMS_opt_S_lenient
 
 -- | Parses text that is formatted Year\/Month\/Day,Hour\/Minute\/Second with
--- the seconds as optional and any non-numeric ascii character as seperators.
+-- the seconds as optional and any non-numeric ascii character as separators.
 --
 -- * @%Y:%M%D %H:%M@
 -- * @%Y:%M%D %H:%M:%S@
@@ -1673,7 +1673,7 @@ parser_lenient :: Parser Datetime
 parser_lenient = parser_YmdHMS_opt_S_lenient <|> parser_DmyHMS_opt_S_lenient
 
 -- | Parses text that was encoded in DMY, YMD, or MDY format with optional
--- seconds and any non-numeric ascii character as seperators.
+-- seconds and any non-numeric ascii character as separators.
 decode_lenient :: Text -> Maybe Datetime
 decode_lenient =
   either (const Nothing) Just . AT.parseOnly parser_lenient

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -959,7 +959,7 @@ parser_Ymd msep = do
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Year\/Month\/Day-encoded 'Date' that either has no separators or
---   uses any non-numeric ascii character for each separator.
+--   uses any non-numeric character for each separator.
 parser_Ymd_lenient :: Parser Date
 parser_Ymd_lenient = do
   y <- parseFixedDigits 4
@@ -1017,7 +1017,7 @@ parser_Dmy msep = do
   pure (Date (Year y) (Month $ m - 1) (DayOfMonth d))
 
 -- | Parse a Day\/Month\/Year-encoded 'Date' that either has no separators or
---   uses any non-numeric ascii character for each separator.
+--   uses any non-numeric character for each separator.
 parser_Dmy_lenient :: Parser Date
 parser_Dmy_lenient = do
   d <- parseFixedDigits 2
@@ -1166,7 +1166,7 @@ parser_HMS_opt_S msep = do
         else pure (TimeOfDay h m 0)
 
 -- | Parses text that is formatted as either of the following with either no
--- separators or any non-numeric ascii characters for each separator:
+-- separators or any non-numeric characters for each separator:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1402,7 +1402,7 @@ decode_YmdHMS format =
   either (const Nothing) Just . AT.parseOnly (parser_YmdHMS format)
 
 -- | Decode a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator.
 decode_YmdHMS_lenient :: Text -> Maybe Datetime
 decode_YmdHMS_lenient =
@@ -1433,7 +1433,7 @@ parser_DmyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parse a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator, such as:
 --
 -- 01-05-2017T23:13:05
@@ -1448,7 +1448,7 @@ parser_DmyHMS_lenient = do
     Nothing -> Datetime <$> parser_Dmy_lenient <* parserLenientSeparator <*> parser_HMS_lenient
 
 -- | Parse a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
@@ -1465,7 +1465,7 @@ parser_DmyHMS_opt_S_lenient = do
     Nothing -> Datetime <$> parser_Dmy_lenient <* parserLenientSeparator <*> parser_HMS_opt_S_lenient
 
 -- | Decodes Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
--- 'Text' that is encoded with either no separators or any non-numeric ascii
+-- 'Text' that is encoded with either no separators or any non-numeric
 -- characters as separators, such as:
 --
 -- 2017-01-05T23:13:05
@@ -1496,7 +1496,7 @@ decode_DmyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_DmyHMS_opt_S format)
 
 -- | Decode a Day\/Month\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
@@ -1520,8 +1520,8 @@ parser_MdyHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with either no separators or any non-numeric ascii character for
---   each separator.
+--   encoded with either no separators or any non-numeric character for each
+--   separator.
 parser_MdyHMS_lenient :: Parser Datetime
 parser_MdyHMS_lenient = do
   mdate <- optional $ parser_Mdy Nothing
@@ -1546,7 +1546,7 @@ parser_MdyHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parse a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
@@ -1568,8 +1568,8 @@ decode_MdyHMS format =
   either (const Nothing) Just . AT.parseOnly (parser_MdyHMS format)
 
 -- | Decode a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' with either no separators or any non-numeric ascii character for
---   each separator.
+--   'Text' with either no separators or any non-numeric character for each
+--   separator.
 decode_MdyHMS_lenient :: Text -> Maybe Datetime
 decode_MdyHMS_lenient =
   either (const Nothing) Just . AT.parseOnly parser_MdyHMS_lenient
@@ -1588,8 +1588,8 @@ decode_MdyHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_MdyHMS_opt_S format)
 
 -- | Parse a Month\/Day\/Year,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' with either no separators or any non-numeric ascii character for
---   each separator and with either of the following time formats:
+--   'Text' with either no separators or any non-numeric character for each
+--   separator and with either of the following time formats:
 --
 -- * @%H:%M@
 -- * @%H:%M:%S@
@@ -1610,8 +1610,8 @@ parser_YmdHMS (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Year\/Month\/Day,Hour\/Minute\/Second-encoded 'Datetime' that was
---   encoded with either no separators or any non-numeric ascii character for
---   each separator.
+--   encoded with either no separators or any non-numeric character for each
+--   separator.
 parser_YmdHMS_lenient :: Parser Datetime
 parser_YmdHMS_lenient = do
   mdate <- optional $ parser_Ymd Nothing
@@ -1637,7 +1637,7 @@ parser_YmdHMS_opt_S (DatetimeFormat mdateSep msep mtimeSep) = do
   pure (Datetime date time)
 
 -- | Parses a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
@@ -1668,7 +1668,7 @@ decode_YmdHMS_opt_S format =
   either (const Nothing) Just . AT.parseOnly (parser_YmdHMS_opt_S format)
 
 -- | Decode a Year\/Month\/Date,Hour\/Minute\/Second-encoded 'Datetime' from
---   'Text' that was encoded with either no separators or any non-numeric ascii
+--   'Text' that was encoded with either no separators or any non-numeric
 --   character for each separator and with either of the following time formats:
 --
 -- * @%H:%M@
@@ -1681,8 +1681,9 @@ decode_YmdHMS_opt_S_lenient :: Text -> Maybe Datetime
 decode_YmdHMS_opt_S_lenient =
   either (const Nothing) Just . AT.parseOnly parser_YmdHMS_opt_S_lenient
 
--- | Parses a 'Datetime' from 'Text' that was encoded with any of the following formats and with
--- either no separators or any non-numeric ascii character for each separator.
+-- | Parses a 'Datetime' from 'Text' that was encoded with any of the following
+-- formats and with either no separators or any non-numeric character for each
+-- separator.
 --
 -- * @%Y-%M-%D %H:%M@
 -- * @%Y-%M-%D %H:%M:%S@
@@ -1698,7 +1699,7 @@ parser_lenient :: Parser Datetime
 parser_lenient = parser_YmdHMS_opt_S_lenient <|> parser_DmyHMS_opt_S_lenient <|> parser_MdyHMS_opt_S_lenient
 
 -- | Parses text that was encoded in DMY, YMD, or MDY format with optional
--- seconds and any non-numeric ascii character as separators.
+-- seconds and any non-numeric character as separators.
 decode_lenient :: Text -> Maybe Datetime
 decode_lenient =
   either (const Nothing) Just . AT.parseOnly parser_lenient

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -1666,12 +1666,14 @@ decode_YmdHMS_opt_S_lenient =
 -- * @%D:%M%Y %H:%M@
 -- * @%D:%M%Y %H:%M:%S@
 --
--- That is, the seconds and subseconds part is optional. If it is
--- not provided, it is assumed to be zero. This format shows up
--- in Google Chrome\'s @datetime-local@ inputs.
+-- That is, the seconds and subseconds part is optional. If it is not provided,
+-- it is assumed to be zero. Note that this is the least performant parser due
+-- to backtracking
 parser_lenient :: Parser Datetime
 parser_lenient = parser_YmdHMS_opt_S_lenient <|> parser_DmyHMS_opt_S_lenient
 
+-- | Parses text that was encoded in DMY, YMD, or MDY format with optional
+-- seconds and any non-numeric ascii character as seperators.
 decode_lenient :: Text -> Maybe Datetime
 decode_lenient =
   either (const Nothing) Just . AT.parseOnly parser_lenient

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -122,13 +122,37 @@ tests =
       ]
     ]
   , testGroup "Date"
-    [ testGroup "Parser Spec Tests" $
-      [ PH.testCase "No Separator"
-          (dateParse Nothing "20160101" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
-      , PH.testCase "Separator 1"
-          (dateParse (Just '-') "2016-01-01" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
-      , PH.testCase "Separator 2"
-          (dateParse (Just '-') "1876-09-27" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
+    [ testGroup "Ymd Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (dateParse (C.parser_Ymd Nothing) "20160101" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 1"
+          (dateParse (C.parser_Ymd (Just '-')) "2016-01-01" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 2"
+          (dateParse (C.parser_Ymd (Just '-')) "1876-09-27" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
+      ]
+    , testGroup "Dmy Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (dateParse (C.parser_Dmy Nothing) "01012016" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 1"
+          (dateParse (C.parser_Dmy (Just '-')) "01-01-2016" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 2"
+          (dateParse (C.parser_Dmy (Just '-')) "27-09-1876" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
+      ]
+    , testGroup "Ymd Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (dateParse C.parser_Ymd_lenient "20160101" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 1"
+          (dateParse C.parser_Ymd_lenient "2016!01@01" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 2"
+          (dateParse C.parser_Ymd_lenient "1876z09+27" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
+      ]
+    , testGroup "Dmy Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (dateParse C.parser_Dmy_lenient "01012016" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 1"
+          (dateParse C.parser_Dmy_lenient "01!01@2016" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
+      , PH.testCase "Passes With Separator 2"
+          (dateParse C.parser_Dmy_lenient "27z09+1876" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
       ]
     , testGroup "Builder Spec Tests" $
       [ PH.testCase "No Separator"
@@ -143,12 +167,146 @@ tests =
         (either (const Nothing) Just . Atto.parseOnly (C.parser_Ymd (Just '-')))
     ]
   , testGroup "Datetime"
-    [ testProperty "Builder Parser Isomorphism (Y-m-dTH:M:S)" $ propEncodeDecodeIsoSettings
-        (\format -> LText.toStrict . Builder.toLazyText . C.builder_YmdHMS (SubsecondPrecisionFixed 9) format)
-        (\format -> either (const Nothing) Just . Atto.parseOnly (C.parser_YmdHMS format))
-    , testProperty "Builder Parser Isomorphism (YmdHMS)" $ propEncodeDecodeIso
-        (LText.toStrict . Builder.toLazyText . C.builder_YmdHMS (SubsecondPrecisionFixed 9) (DatetimeFormat Nothing Nothing Nothing))
-        (either (const Nothing) Just . Atto.parseOnly (C.parser_YmdHMS (DatetimeFormat Nothing Nothing Nothing)))
+    [ testGroup "DmyHMS Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse (C.parser_DmyHMS (DatetimeFormat Nothing Nothing Nothing)) "01022016010223" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse (C.parser_DmyHMS (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016 01:02:23" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      ]
+    , testGroup "YmdHMS Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse (C.parser_YmdHMS (DatetimeFormat Nothing Nothing Nothing)) "20160101010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse (C.parser_YmdHMS (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-01 01:02:23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      ]
+    , testGroup "DmyHMS Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse C.parser_DmyHMS_lenient "01022016010223" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse C.parser_DmyHMS_lenient "01z02x2016$01;02:23" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_DmyHMS_lenient "01-02-2016  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "YmdHMS Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse C.parser_YmdHMS_lenient "20160101010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse C.parser_YmdHMS_lenient "2016!01z01^01a02c23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_YmdHMS_lenient "2016-01-02  01:02:03" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "DmyHMS Optional Seconds Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator With Seconds"
+          (datetimeParse (C.parser_DmyHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "01022016010223" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator Without Seconds"
+          (datetimeParse (C.parser_DmyHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "010220160102" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator With Seconds"
+          (datetimeParse (C.parser_DmyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016 01:02:23" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator Without Seconds"
+          (datetimeParse (C.parser_DmyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016 01:02" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail (C.parser_DmyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016 01:02:" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail (C.parser_DmyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "YmdHMS Optional Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator With Seconds"
+          (datetimeParse (C.parser_YmdHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "20160101010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator Without Seconds"
+          (datetimeParse (C.parser_YmdHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "201601010102" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator With Seconds"
+          (datetimeParse (C.parser_YmdHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-01 01:02:23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator Without Seconds"
+          (datetimeParse (C.parser_YmdHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-01 01:02" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail (C.parser_YmdHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-02 01:02:" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail (C.parser_YmdHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-02  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "DmyHMS Optional Seconds Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator with seconds"
+          (datetimeParse C.parser_DmyHMS_opt_S_lenient "01022016010223" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator without seconds"
+          (datetimeParse C.parser_DmyHMS_opt_S_lenient "010220160102" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator with seconds"
+          (datetimeParse C.parser_DmyHMS_opt_S_lenient "01z02x2016$01;02:23" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator without seconds"
+          (datetimeParse C.parser_DmyHMS_opt_S_lenient "01z02x2016$01;02" $
+            Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail C.parser_DmyHMS_opt_S_lenient "01z02x2016$01;02^" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_DmyHMS_opt_S_lenient "01-02-2016  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "YmdHMS Optional Seconds Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator With Seconds"
+          (datetimeParse C.parser_YmdHMS_opt_S_lenient "20160101010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator Without Seconds"
+          (datetimeParse C.parser_YmdHMS_opt_S_lenient "201601010102" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator With Seconds"
+          (datetimeParse C.parser_YmdHMS_opt_S_lenient "2016!01z01^01a02c23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator Without Seconds"
+          (datetimeParse C.parser_YmdHMS_opt_S_lenient "2016!01z01^01a02" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail C.parser_YmdHMS_opt_S_lenient "2016!01z01^01a02^" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_YmdHMS_opt_S_lenient "2016-01-02  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "Builder Parser Isomorphism" $
+      [ testProperty "(Y-m-dTH:M:S)" $ propEncodeDecodeIsoSettings
+          (\format -> LText.toStrict . Builder.toLazyText . C.builder_YmdHMS (SubsecondPrecisionFixed 9) format)
+          (\format -> either (const Nothing) Just . Atto.parseOnly (C.parser_YmdHMS format))
+      , testProperty "Builder Parser Isomorphism (YmdHMS)" $ propEncodeDecodeIso
+          (LText.toStrict . Builder.toLazyText . C.builder_YmdHMS (SubsecondPrecisionFixed 9) (DatetimeFormat Nothing Nothing Nothing))
+          (either (const Nothing) Just . Atto.parseOnly (C.parser_YmdHMS (DatetimeFormat Nothing Nothing Nothing)))
+      ]
     ]
   , testGroup "Offset Datetime"
     [ testGroup "Builder Spec Tests" $
@@ -279,10 +437,25 @@ bsTimeOfDayBuilder sp m expected tod =
   LText.toStrict (Builder.toLazyText (C.builder_HMS sp m tod))
   @?= expected
 
-dateParse :: Maybe Char -> Text -> Date -> Assertion
-dateParse m t expected =
-  Atto.parseOnly (C.parser_Ymd m <* Atto.endOfInput) t
+dateParse :: Atto.Parser Date -> Text -> Date -> Assertion
+dateParse p t expected =
+  Atto.parseOnly (p <* Atto.endOfInput) t
   @?= Right expected
+
+--dateParseFail :: Atto.Parser Date -> Text -> String -> Assertion
+--dateParseFail p t expected =
+--  Atto.parseOnly (p <* Atto.endOfInput) t
+--  @?= Left expected
+
+datetimeParse :: Atto.Parser Datetime -> Text -> Datetime -> Assertion
+datetimeParse p t expected =
+  Atto.parseOnly (p <* Atto.endOfInput) t
+  @?= Right expected
+
+datetimeParseFail :: Atto.Parser Datetime -> Text -> String -> Assertion
+datetimeParseFail p t expected =
+  Atto.parseOnly (p <* Atto.endOfInput) t
+  @?= Left expected
 
 dateBuilder :: Maybe Char -> Text -> Date -> Assertion
 dateBuilder m expected tod =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -187,6 +187,16 @@ tests =
             Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
           )
       ]
+    , testGroup "MdyHMS Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse (C.parser_MdyHMS (DatetimeFormat Nothing Nothing Nothing)) "01012016010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse (C.parser_MdyHMS (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-01-2016 01:02:23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      ]
     , testGroup "DmyHMS Lenient Parser Spec Tests" $
       [ PH.testCase "Passes With No Separator"
           (datetimeParse C.parser_DmyHMS_lenient "01022016010223" $
@@ -210,6 +220,18 @@ tests =
           )
       , PH.testCase "Fails with extra seperators"
           (datetimeParseFail C.parser_YmdHMS_lenient "2016-01-02  01:02:03" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "MdyHMS Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (datetimeParse C.parser_MdyHMS_lenient "01012016010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator"
+          (datetimeParse C.parser_MdyHMS_lenient "01z01%2016^01a02c23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_MdyHMS_lenient "01-02-2016  01:02:03" "Failed reading: input does not start with a digit")
       ]
     , testGroup "DmyHMS Optional Seconds Parser Spec Tests" $
       [ PH.testCase "Passes With No Separator With Seconds"
@@ -255,6 +277,28 @@ tests =
       , PH.testCase "Fails with extra seperators"
           (datetimeParseFail (C.parser_YmdHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "2016-01-02  01:02" "Failed reading: input does not start with a digit")
       ]
+    , testGroup "MdyHMS Optional Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator With Seconds"
+          (datetimeParse (C.parser_MdyHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "01012016010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator Without Seconds"
+          (datetimeParse (C.parser_MdyHMS_opt_S (DatetimeFormat Nothing Nothing Nothing)) "010120160102" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator With Seconds"
+          (datetimeParse (C.parser_MdyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-01-2016 01:02:23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator Without Seconds"
+          (datetimeParse (C.parser_MdyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-01-2016 01:02" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail (C.parser_MdyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016 01:02:" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail (C.parser_MdyHMS_opt_S (DatetimeFormat (Just '-') (Just ' ') (Just ':'))) "01-02-2016  01:02" "Failed reading: input does not start with a digit")
+      ]
     , testGroup "DmyHMS Optional Seconds Lenient Parser Spec Tests" $
       [ PH.testCase "Passes With No Separator with seconds"
           (datetimeParse C.parser_DmyHMS_opt_S_lenient "01022016010223" $
@@ -298,6 +342,28 @@ tests =
           (datetimeParseFail C.parser_YmdHMS_opt_S_lenient "2016!01z01^01a02^" "not enough input")
       , PH.testCase "Fails with extra seperators"
           (datetimeParseFail C.parser_YmdHMS_opt_S_lenient "2016-01-02  01:02" "Failed reading: input does not start with a digit")
+      ]
+    , testGroup "MdyHMS Optional Seconds Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator With Seconds"
+          (datetimeParse C.parser_MdyHMS_opt_S_lenient "01012016010223" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With No Separator Without Seconds"
+          (datetimeParse C.parser_MdyHMS_opt_S_lenient "010120160102" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Passes With With Separator With Seconds"
+          (datetimeParse C.parser_MdyHMS_opt_S_lenient "01z01!2016^01a02c23" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
+          )
+      , PH.testCase "Passes With With Separator Without Seconds"
+          (datetimeParse C.parser_MdyHMS_opt_S_lenient "01z01(2016^01a02" $
+            Datetime (Date (Year 2016) (Month 0) (DayOfMonth 1)) (TimeOfDay 01 02 0)
+          )
+      , PH.testCase "Fails with trailing seperator"
+          (datetimeParseFail C.parser_MdyHMS_opt_S_lenient "01z01!2016^01a02^" "not enough input")
+      , PH.testCase "Fails with extra seperators"
+          (datetimeParseFail C.parser_MdyHMS_opt_S_lenient "01-02-2016  01:02" "Failed reading: input does not start with a digit")
       ]
     , testGroup "Builder Parser Isomorphism" $
       [ testProperty "(Y-m-dTH:M:S)" $ propEncodeDecodeIsoSettings

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -154,6 +154,14 @@ tests =
       , PH.testCase "Passes With Separator 2"
           (dateParse C.parser_Dmy_lenient "27z09+1876" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
       ]
+    , testGroup "Mdy Lenient Parser Spec Tests" $
+      [ PH.testCase "Passes With No Separator"
+          (dateParse C.parser_Mdy_lenient "01022016" (Date (Year 2016) (Month 0) (DayOfMonth 2)))
+      , PH.testCase "Passes With Separator 1"
+          (dateParse C.parser_Mdy_lenient "01!02@2016" (Date (Year 2016) (Month 0) (DayOfMonth 2)))
+      , PH.testCase "Passes With Separator 2"
+          (dateParse C.parser_Mdy_lenient "09+27z1876" (Date (Year 1876) (Month 8) (DayOfMonth 27)))
+      ]
     , testGroup "Builder Spec Tests" $
       [ PH.testCase "No Separator"
           (dateBuilder Nothing "20160101" (Date (Year 2016) (Month 0) (DayOfMonth 1)))
@@ -207,7 +215,9 @@ tests =
             Datetime (Date (Year 2016) (Month 1) (DayOfMonth 1)) (TimeOfDay 01 02 23000000000)
           )
       , PH.testCase "Fails with extra seperators"
-          (datetimeParseFail C.parser_DmyHMS_lenient "01-02-2016  01:02" "Failed reading: input does not start with a digit")
+          (datetimeParseFail C.parser_DmyHMS_lenient "01-02-2016  01:02:23" "Failed reading: input does not start with a digit")
+      , PH.testCase "Fails with some nonuniform empty Separators"
+          (datetimeParseFail C.parser_DmyHMS_lenient "01-02-201601:02:23" "Failed reading: satisfy")
       ]
     , testGroup "YmdHMS Lenient Parser Spec Tests" $
       [ PH.testCase "Passes With No Separator"


### PR DESCRIPTION
This commit adds the following exposed functions:

```
parser_Ymd_lenient :: Parser Date
parser_Dmy_lenient :: Parser Date
parser_Mdy_lenient :: Parser Date

parser_DmyHMS_lenient :: Parser Datetime
parser_DmyHMS_opt_S_lenient :: Parser Datetime
parser_MdyHMS :: DatetimeFormat -> Parser Datetime
parser_MdyHMS_lenient :: Parser Datetime
parser_MdyHMS_opt_S :: DatetimeFormat -> Parser Datetime
parser_MdyHMS_opt_S_lenient :: Parser Datetime
parser_YmdHMS_lenient :: Parser Datetime
parser_YmdHMS_opt_S_lenient :: Parser Datetime

decode_DmyHMS_lenient :: Text -> Maybe Datetime
decode_DmyHMS_opt_S_lenient :: Text -> Maybe Datetime
decode_MdyHMS :: DatetimeFormat -> Text -> Maybe Datetime
decode_MdyHMS_lenient :: Text -> Maybe Datetime
decode_MdyHMS_opt_S :: DatetimeFormat -> Text -> Maybe Datetime
decode_MdyHMS_opt_S_lenient :: Text -> Maybe Datetime
decode_YmdHMS_lenient :: Text -> Maybe Datetime
decode_YmdHMS_opt_S_lenient :: Text -> Maybe Datetime

parser_lenient :: Parser Datetime
decode_lenient :: Text -> Maybe Datetime
```

Lenient functions can take any non-numeric ascii character or no character for their seperators. Mdy functions were added because I noticed there was already an unused Mdy Date parser.

`parser_lenient` attempts all `_opt_S_lenient` parsers.

Unit tests were added for all parsers.