### PR TITLE
[#42] Add Appveyor config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # Chronos
 
+[![Windows build](https://ci.appveyor.com/api/projects/status/github/andrewthad/chronos?branch=master&svg=true)](https://ci.appveyor.com/project/andrewthad/chronos)
+
 Chronos is a performance-oriented time library for Haskell, with a
 straightforward API. The main differences between this
 and the [time](http://hackage.haskell.org/package/time) library

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+clone_folder: "c:\\WORK"
+clone_depth: 5
+
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+platform:
+  - x86_64
+
+cache:
+  - "C:\\SR"
+  - dist-newstyle
+
+environment:
+  global:
+    CABOPTS: --store-dir=C:\\SR
+
+  matrix:
+    - GHCVER: 8.8.1
+
+install:
+  - choco source add -n mistuke -s https://www.myget.org/F/mistuke/api/v2
+  - choco install -y cabal --version 3.0.0.0
+  - choco install -y ghc   --version 8.8.1
+  - refreshenv
+
+before_build:
+  - cabal --version
+  - ghc   --version
+  - cabal %CABOPTS% update
+
+build_script:
+  - cabal %CABOPTS% build all --enable-tests
+  - cabal %CABOPTS% test  all --enable-tests


### PR DESCRIPTION
Resolves #42

This PR adds the config file. In order to actually turn on Appveyor for the repository you should actually sign in at appveyor.com and to add `chronos`. Here are the docs that should help: https://www.appveyor.com/docs/

Let me know if you have any questions or comments about this.