### PR TITLE
Benchmark should convert to the tight rep to be fair

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -46,6 +46,10 @@ main = do
       Thyme.buildTime @Thyme.UTCTime
       . either error id
       . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString)
+    -- With chronos, we explicitly convert the ymdhms time to the
+    -- nanoseconds since the epoch. This is done to make the benchmark
+    -- compare apples to apples. Both thyme and time are computing epoch
+    -- times, so we want chronos to do the same.
     chronosAttoparsec :: BS8.ByteString -> Chronos.Time
     chronosAttoparsec =
       either error Chronos.datetimeToTime

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -46,13 +46,13 @@ main = do
       Thyme.buildTime @Thyme.UTCTime
       . either error id
       . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString)
-    chronosAttoparsec :: BS8.ByteString -> Chronos.Datetime
+    chronosAttoparsec :: BS8.ByteString -> Chronos.Time
     chronosAttoparsec =
-      either error id
+      either error Chronos.datetimeToTime
       . parseOnly (Chronos.parserUtf8_YmdHMS Chronos.w3c)
-    chronosZepto :: BS8.ByteString -> Chronos.Datetime
+    chronosZepto :: BS8.ByteString -> Chronos.Time
     chronosZepto =
-      either error id
+      either error Chronos.datetimeToTime
       . Z.parse (Chronos.zeptoUtf8_YmdHMS Chronos.w3c)
 
     dmy              = "%d:%m:%y."
@@ -120,3 +120,4 @@ deriving instance NFData Chronos.DayOfMonth
 deriving instance NFData Chronos.Month
 deriving instance NFData Chronos.Year
 deriving instance NFData Chronos.Day
+deriving instance NFData Chronos.Time


### PR DESCRIPTION
I realized the parsing benchmarks weren't completely fair as they didn't pay for converting to the tight POSIX representation, so I have fixed that.

I reran the benchmarks and it barely made a difference though, it's the string munging which requires all the work.

Can understand if you don't want to merge though, maybe this _is_ the use case that you are thinking of.