### PR TITLE
Implement timeToDayOfWeek and datetimeToDayOfWeek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.1: [2020.??.??]
+-----------------
+* Add `timeToDayOfWeek`, `datetimeToDayOfWeek`, `todayDayOfWeek`,
+  `yesterdayDayOfWeek`, and `tomorrowDayOfWeek`.
+* Remove `stopwatchWith(_)` on GHC 8.6+.
+
 1.1: [2019.11.28]
 -----------------
 * Drop dependency of `clock` on GHC 8.6+.

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   chronos
 version:
-  1.1
+  1.1.1
 synopsis:
   A performant time library
 description:

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -446,6 +446,40 @@ tests =
        [ testProperty "Verify TimeInterval construction correctness" propTimeIntervalBuilder
        ]
     ]
+  , testGroup "Datetime Conversions"
+    [ testGroup "datetimeToDayOfWeek"
+      [ PH.testCase "February 2nd 2020"
+        (C.datetimeToDayOfWeek (Datetime (Date (Year 2020) (Month 1) (DayOfMonth 2)) (TimeOfDay 0 0 0)) @?= DayOfWeek 0)
+      , PH.testCase "July 10th 2019"
+        (C.datetimeToDayOfWeek (Datetime (Date (Year 2019) (Month 6) (DayOfMonth 10)) (TimeOfDay 0 0 0)) @?= DayOfWeek 3)
+      , PH.testCase "November 16th 1946"
+        (C.datetimeToDayOfWeek (Datetime (Date (Year 1946) (Month 10) (DayOfMonth 16)) (TimeOfDay 0 0 0)) @?= DayOfWeek 6)
+      , PH.testCase "February 29th 2024 (Leap Year)"
+        (C.datetimeToDayOfWeek (Datetime (Date (Year 2024) (Month 1) (DayOfMonth 29)) (TimeOfDay 0 0 0)) @?= DayOfWeek 4)
+      ]
+    ]
+  , testGroup "timeToDayOfWeek Conversions"
+    [ PH.testCase "Sunday, February 9, 2020 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 1581264000000000000) @?= DayOfWeek 0)
+    , PH.testCase "Monday, April 9, 2001 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 986832000000000000) @?= DayOfWeek 1)
+    , PH.testCase "Tuesday, March 7, 1995 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 794592000000000000) @?= DayOfWeek 2)
+    , PH.testCase "Wednesday, June 17, 1987 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 550944000000000000) @?= DayOfWeek 3)
+    , PH.testCase "Thursday, December 18, 1980 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 346003200000000000) @?= DayOfWeek 4)
+    , PH.testCase "Friday, October 10, 1975 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 182188800000000000) @?= DayOfWeek 5)
+    , PH.testCase "Saturday, August 11, 1973 4:00:00 PM"
+      (C.timeToDayOfWeek (Time 113932800000000000) @?= DayOfWeek 6)
+    , PH.testCase "Thursday, January 1, 1970 12:00:00 AM"
+      (C.timeToDayOfWeek (Time 0) @?= DayOfWeek 4)
+    , PH.testCase "Saturday, June 14, 1969 4:00:00 PM"
+      (C.timeToDayOfWeek (Time (-17308800000000000)) @?= DayOfWeek 6)
+    , PH.testCase "Tuesday, June 6, 1944 4:00:00 PM"
+      (C.timeToDayOfWeek (Time (-806918400000000000)) @?= DayOfWeek 2)
+    ]
   ]
 
 failure :: String -> Result


### PR DESCRIPTION
This converts from a datetime to a day of week account for leap year. Also, adds todayDayOfWeek, yesterdayDayOfWeek, and tomorrowDayOfWeek. Originally, this work was at https://github.com/andrewthad/chronos/pull/49. This PR is the same thing but squashed and rebased for a cleaner git history.

Algorithm for datetime conversion adapted from:
https://cs.uwaterloo.ca/~alopez-o/math-faq/node73.html

Algorithm for nanoseconds-since-epoch conversion adapted from:
https://stackoverflow.com/q/36357013/1405768