### PR TITLE
don't export undefined CTimespec on ghcjs

### DIFF
--- a/src/Chronos/Internal/CTimespec.hs
+++ b/src/Chronos/Internal/CTimespec.hs
@@ -7,7 +7,9 @@ module Chronos.Internal.CTimespec
   (
 #ifndef mingw32_HOST_OS
     getPosixNanoseconds
+#ifndef ghcjs_HOST_OS
   , CTimespec(..)
+#endif
 #endif
   ) where
 


### PR DESCRIPTION
it's pretty straightforward – `CTimespec` is defined in an `#else` if `ghcjs_HOST_OS` is not defined.