### PR TITLE
fix month off by one for windows: add torsor to test dependencies

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -119,6 +119,7 @@ test-suite doctest
     , chronos
     , deepseq >= 1.4.4.0
     , doctest >= 0.10
+    , torsor >= 0.1 && < 0.2
   default-language:
     Haskell2010
 

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -510,7 +510,7 @@ now = do
   SYSTEMTIME{..} <- W32.getSystemTime
   let date = Date
         { dateYear  = Year       (fromIntegral wYear)
-        , dateMonth = Month      (fromIntegral wMonth)
+        , dateMonth = Month      (fromIntegral wMonth - 1)
         , dateDay   = DayOfMonth (fromIntegral wDay)
         }
   let secNano = (fromIntegral wSecond :: Int64) * 1000000000

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -474,7 +474,7 @@ datetimeFromYmdhms y m d h m' s = Datetime
   where
   mx = if m >= 1 && m <= 12
     then fromIntegral (m - 1)
-    else 1
+    else 0
 
 -- | Construct a 'Time' from year, month, day, hour, minute, second:
 --


### PR DESCRIPTION
Hi,
Here is a pull request that corrects the month for the windows build. 
Also a very minor thing, but should datetimeFromYmdhms return zero instead of one when the month is out of range?

...
  mx = if m >= 1 && m <= 12
    then fromIntegral (m - 1)
    else 1  --- should this be zero instead?
...
Best,
Grant
