### PR TITLE
Support aeson-2.0*

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -46,7 +46,7 @@ library
     -- it is OPTIONS_HADDOCK-hidden
       Chronos.Internal.CTimespec
   build-depends:
-    , aeson >= 1.1 && < 1.6
+    , aeson >= 1.1 && < 2.1
     , attoparsec >= 0.13 && < 0.15
     , base >= 4.12 && < 5
     , bytestring >= 0.10 && < 0.11


### PR DESCRIPTION
There is one breaking change affecting this package, see
https://github.com/haskell/aeson/pull/868/files for details.
Old `aeson` versions are still supported since we are using CPP
to check the version.