### PR TITLE
Support text 2

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -54,7 +54,7 @@ library
     , hashable >= 1.2 && < 1.5
     , primitive >= 0.6.4 && < 0.8
     , semigroups >= 0.16 && < 0.20
-    , text >= 1.2 && < 1.3
+    , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
     , torsor >= 0.1 && < 0.2
     , vector >= 0.11 && < 0.13
     , bytebuild >= 0.3.8 && < 0.4

--- a/src/Chronos/Internal/FastText.hs
+++ b/src/Chronos/Internal/FastText.hs
@@ -6,7 +6,6 @@ module Chronos.Internal.FastText where
 import Data.Text (Text)
 import Control.Monad.ST (ST)
 import qualified Data.Text.Internal as I
-import qualified Data.Text as Text
 import qualified Data.Text.Array as A
 import qualified Data.Text.Internal.Unsafe.Char as C
 


### PR DESCRIPTION
chronos doesn't seem to be affected by the breaking changes in the text 2.0 package. There is only `Chronos.Internal.FastText` module that uses some internal functions where the behavious may have changed. But `FastText` doesn't seem to be used anywhere, isn't exported publically and isn't tested.