### PR TITLE
Bump upper bound for semigroups

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -53,7 +53,7 @@ library
     , deepseq >= 1.4.4.0
     , hashable >= 1.2 && < 1.5
     , primitive >= 0.6.4 && < 0.8
-    , semigroups >= 0.16 && < 0.20
+    , semigroups >= 0.16 && < 0.21
     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
     , torsor >= 0.1 && < 0.2
     , vector >= 0.11 && < 0.13


### PR DESCRIPTION
Hello,

could you please accept this bump to upper bounds?
The current bound is too restrictive and doesn't allow building with semigroups 0.20 present in stackage nightly (https://www.stackage.org/nightly-2022-10-24/package/semigroups-0.20).
Thank you for your consideration.