### PR TITLE
build with primitive 0.8

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -52,11 +52,11 @@ library
     , bytestring >= 0.10 && < 0.12
     , deepseq >= 1.4.4.0
     , hashable >= 1.2 && < 1.5
-    , primitive >= 0.6.4 && < 0.8
+    , primitive >= 0.6.4 && < 0.9
     , semigroups >= 0.16 && < 0.21
     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
     , torsor >= 0.1 && < 0.2
-    , vector >= 0.11 && < 0.13
+    , vector >= 0.11 && < 0.14
     , bytebuild >= 0.3.8 && < 0.4
     , bytesmith >= 0.3.7 && < 0.4
     , byteslice >= 0.2.5.2 && <0.3


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=bytesmith:primitive --allow-newer=wide-word:primitive --allow-newer=run-st:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=contiguous:primitive --allow-newer=byteslice:primitive --allow-newer=tuples:primitive --allow-newer=primitive-addr:primitive --allow-newer=bytebuild:primitive --allow-newer=aeson:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - bytebuild-0.3.12.0 (lib) (requires build)
 - bytesmith-0.3.9.1 (lib) (requires build)
 - semigroups-0.20 (lib) (requires build)
 - torsor-0.1 (lib) (requires build)
 - chronos-1.1.5 (lib) (first run)
Starting     semigroups-0.20 (lib)
Starting     torsor-0.1 (lib)
Starting     bytesmith-0.3.9.1 (lib)
Starting     bytebuild-0.3.12.0 (lib)
Building     semigroups-0.20 (lib)
Building     torsor-0.1 (lib)
Building     bytesmith-0.3.9.1 (lib)
Building     bytebuild-0.3.12.0 (lib)
Installing   torsor-0.1 (lib)
Installing   semigroups-0.20 (lib)
Completed    torsor-0.1 (lib)
Completed    semigroups-0.20 (lib)
Installing   bytesmith-0.3.9.1 (lib)
Completed    bytesmith-0.3.9.1 (lib)
Installing   bytebuild-0.3.12.0 (lib)
Completed    bytebuild-0.3.12.0 (lib)
Configuring library for chronos-1.1.5..
Preprocessing library for chronos-1.1.5..
Building library for chronos-1.1.5..
[1 of 4] Compiling Chronos.Internal.CTimespec ( src/Chronos/Internal/CTimespec.hs, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Internal/CTimespec.o, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Internal/CTimespec.dyn_o )
[2 of 4] Compiling Chronos          ( src/Chronos.hs, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos.o, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos.dyn_o )
[3 of 4] Compiling Chronos.Types    ( src/Chronos/Types.hs, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Types.o, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Types.dyn_o )
[4 of 4] Compiling Chronos.Locale.English ( src/Chronos/Locale/English.hs, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Locale/English.o, /home/chessai/haskell/chronos/dist-newstyle/build/x86_64-linux/ghc-9.4.4/chronos-1.1.5/build/Chronos/Locale/English.dyn_o )
```