### PR TITLE
Allow base 4.18

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
     , aeson >= 1.1 && < 2.2
     , attoparsec >= 0.13 && < 0.15
-    , base >= 4.14 && < 4.18
+    , base >= 4.14 && < 4.19
     , bytestring >= 0.10 && < 0.12
     , deepseq >= 1.4.4.0
     , hashable >= 1.2 && < 1.5


### PR DESCRIPTION
Build and tests succeed with ghc 9.6.2 with
- git: https://github.com/byteverse/bytebuild.git commit: 32034ac3232130a81879db022a38024b8e0ab27c
- git: https://github.com/costarastrology/zigzag.git commit: 63c417592e36d163d1992553d142bd09615d7f72