### PR TITLE
Support GHC 8.10 to 9.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+# Trigger the workflow on push or pull request, but only for the main branch
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: chronos.cabal
+          ubuntu: true
+          version: 0.1.6.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+      - name: Configure
+        run: cabal configure --enable-tests
+      - name: Freeze
+        run: cabal freeze
+      - name: Cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
+      - name: Build
+        run: cabal new-build
+      - name: Test
+        run: cabal new-test all

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -49,8 +49,8 @@ library
   build-depends:
     , aeson >= 1.1 && < 2.3
     , attoparsec >= 0.13 && < 0.15
-    , base >= 4.14 && < 4.19
-    , bytestring >= 0.10 && < 0.12
+    , base >= 4.14 && < 4.20
+    , bytestring >= 0.10 && < 0.13
     , deepseq >= 1.4.4.0
     , hashable >= 1.2 && < 1.5
     , primitive >= 0.6.4 && < 0.10
@@ -58,7 +58,7 @@ library
     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.2
     , torsor >= 0.1 && < 0.2
     , vector >= 0.11 && < 0.14
-    , bytebuild >= 0.3.8 && < 0.4
+    , bytebuild >= 0.3.14 && < 0.4
     , bytesmith >= 0.3.7 && < 0.4
     , byteslice >= 0.2.5.2 && <0.3
     , text-short >= 0.1.3 && <0.2

--- a/chronos.cabal
+++ b/chronos.cabal
@@ -35,6 +35,7 @@ maintainer:
 copyright: 2016 Andrew Martin
 category: Data, Time, Parsing, Development
 build-type: Simple
+tested-with: GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.1
 
 library
   hs-source-dirs: src

--- a/src/Chronos.hs
+++ b/src/Chronos.hs
@@ -1,5 +1,6 @@
 {-# language BangPatterns #-}
 {-# language CPP #-}
+{-# language DataKinds #-}
 {-# language DeriveGeneric #-}
 {-# language GeneralizedNewtypeDeriving #-}
 {-# language LambdaCase #-}
@@ -11,7 +12,6 @@
 {-# language ScopedTypeVariables #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
-{-# language TypeInType #-}
 {-# language UnboxedTuples #-}
 
 {-| Chronos is a performance-oriented time library for Haskell, with a

--- a/src/Chronos/Internal/CTimespec.hs
+++ b/src/Chronos/Internal/CTimespec.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP #-}
+
+#if defined(ghcjs_HOST_OS)
 {-# LANGUAGE JavaScriptFFI #-}
+#endif
 
 {-# OPTIONS_HADDOCK hide #-} -- for doctests
 


### PR DESCRIPTION
This PR introduces a GitHub Action matrix that tests GHC versions from 8.10.7 to 9.8.1, based on the `tested-with` metadata from the cabal file.

It supersedes #86